### PR TITLE
Fixes relative paths being appended by cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 test/temp
-
+.idea
 

--- a/lib/prependurl.js
+++ b/lib/prependurl.js
@@ -29,6 +29,9 @@ module.exports = function(filename, sourceFilename, hostUrl, isContentFileRevved
   }
 
   if (!isContentFileRevved) {
+    if (filename.charAt(0) === '.' && filename.charAt(1) === '.' && filename.charAt(2) === '/') {
+      return hostUrl + filename.replace(/^\.\./, '');
+    }
     return hostUrl + '/' + filename;
   }
 


### PR DESCRIPTION
This change is necessary because unrevved css files with
url()'s would get converted from

url("../images/directives/smile.png") changed to
url("cdnHost/../images/directives/smile.png")
since we would just add host + / without checking if the file
was relative or not.
